### PR TITLE
Add non-root Ruby-based Jekyll setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "Jekyll Dev Container",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "jekyll",
+  "workspaceFolder": "/app",
+  "remoteUser": "jekyll",
+  "extensions": ["rebornix.Ruby"],
+  "forwardPorts": [4000],
+  "postCreateCommand": "bundle install"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2
+
+# install Jekyll and bundler
+RUN gem install jekyll bundler
+
+# create non-root user
+RUN useradd -m jekyll
+
+WORKDIR /app
+
+USER jekyll
+
+ENTRYPOINT ["jekyll", "serve", "--watch", "--force_polling"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  jekyll:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - "4000:4000"
+    working_dir: /app


### PR DESCRIPTION
## Summary
- build container from ruby:3.2 with Jekyll installed
- run Jekyll as non-root user and mount project root
- update devcontainer to use new image and user

## Testing
- `git status --short`